### PR TITLE
Added max_samples for consensus clustering/consensus matrix

### DIFF
--- a/signatureanalyzer/__main__.py
+++ b/signatureanalyzer/__main__.py
@@ -162,6 +162,11 @@ def main():
         help="Random seed for decomposition",
         default=None,
     )
+    parser.add_argument(
+        '--consensus_max_samples',
+        help="Maximum number of samples to include in consensus matrix after NMF (only applies when type='matrix')",
+        default=1000,
+    )
 
     # -----------------------------------------
     # NMF Post-processing Arguments

--- a/signatureanalyzer/consensus.py
+++ b/signatureanalyzer/consensus.py
@@ -24,7 +24,9 @@ def consensus_cluster(filepath: str, max_samples=1000):
     """
     niter = get_nruns_from_output(filepath)
     H_selected = pd.read_hdf(filepath, "H")
-    H_selected = H_selected.sample(max_samples, replace=True)
+    
+    if H_selected.shape[0] > max_samples:
+        H_selected = H_selected.sample(max_samples, replace=True)
 
     x = np.vstack([pd.read_hdf(filepath, "run{}/H".format(i)).loc[H_selected.index,'max_id'].values for i in range(niter)])
     consensus_matrix = np.vstack([(x[:,[y]] == x[:]).sum(0) for y in range(x.shape[1])])

--- a/signatureanalyzer/plotting/_nmf.py
+++ b/signatureanalyzer/plotting/_nmf.py
@@ -47,6 +47,7 @@ def consensus_matrix(
     color_thresh_scale: float = 0.3,
     figsize: tuple = (8,8),
     p: int = 30,
+    max_samples=1000,
     metas: Union[list, None] = None,
     vmax: Union[float, None] = None,
     vmin: Union[float, None] = None,
@@ -66,6 +67,8 @@ def consensus_matrix(
         * color_thresh_scale: asthetic scale for coloring of dendrogram
         * figsize: figsize
         * p: parameter for dendrogram
+        * max_samples: the maximum number of samples the consensus matrix could
+                       have included
         * meta: list of pd.Series that includes a variable of interest to plot
             to left of plot; must be categorical in nature
 
@@ -238,6 +241,9 @@ def consensus_matrix(
     for _, spine in ax.spines.items():
         spine.set_visible(True)
 
-    ax.set_xlabel("Samples", fontsize=14)
+    xlabel = "Samples"
+    if cmatrix.shape[0] == max_samples:
+        xlabel = f"Samples (downsampled to n={max_samples})"
+    ax.set_xlabel(xlabel, fontsize=14)
 
     return fig, rs

--- a/signatureanalyzer/signatureanalyzer.py
+++ b/signatureanalyzer/signatureanalyzer.py
@@ -284,6 +284,7 @@ def run_matrix(
     nruns: int = 20,
     verbose: bool = False,
     plot_results: bool = True,
+    consensus_max_samples: int = 1000,
     **nmf_kwargs
     ):
     """
@@ -305,6 +306,8 @@ def run_matrix(
         * outdir: output directory to save files
         * nruns: number of iterations for ARD-NMF
         * verbose: bool
+        * consensus_max_samples: maximum number of samples to include in 
+                                 consensus clustering after factorization
 
     NMF_kwargs:
         * K0: starting number of latent components
@@ -393,8 +396,10 @@ def run_matrix(
 
     # Consensus Clustering
     print("   * Computing consensus matrix")
-    cmatrix, _ = consensus_cluster(os.path.join(outdir, 'nmf_output.h5'))
-    f,d = consensus_matrix(cmatrix, n_clusters=max_k_iter)
+    cmatrix, _ = consensus_cluster(os.path.join(outdir, 'nmf_output.h5'),
+                                   max_samples=consensus_max_samples)
+    f,d = consensus_matrix(cmatrix, n_clusters=max_k_iter, 
+                           max_samples=consensus_max_samples)
 
     cmatrix.to_csv(os.path.join(outdir, 'consensus_matrix.tsv'), sep='\t')
     d.to_csv(os.path.join(outdir, 'consensus_assign.tsv'), sep='\t')

--- a/signatureanalyzer/signatureanalyzer.py
+++ b/signatureanalyzer/signatureanalyzer.py
@@ -66,7 +66,7 @@ def run_maf(
             will perform decomposition using CPU.
 3    """
     try:
-        [nmf_kwargs.pop(key) for key in ['input', 'type', 'random_seed']]
+        [nmf_kwargs.pop(key) for key in ['input', 'type', 'random_seed', 'consensus_max_samples']]
     except:
         pass
 
@@ -195,7 +195,7 @@ def run_spectra(
             will perform decomposition using CPU.
     """
     try:
-        [nmf_kwargs.pop(key) for key in ['input', 'type', 'hg_build', 'random_seed']]
+        [nmf_kwargs.pop(key) for key in ['input', 'type', 'hg_build', 'random_seed', 'consensus_max_samples']]
     except:
         pass
 


### PR DESCRIPTION
`run_matrix` had some undesirable behaviors on large datasets.

Specifically, the post-NMF consensus clustering/consensus matrix plotting had O(N^2) memory usage (where N is the number of samples). It constructed a dense NxN matrix.

This PR imposes a default maximum of 1000 samples included in consensus clustering/consensus matrix construction. (The number can be re-specified as a kwarg if so desired.) If the size of the dataset exceeds this limit, then the dataset will be downsampled to the limit *for the purposes of consensus clustering*. NMF is unaffected by this PR.

Let me know if this PR needs any additional tweaks :)