### PR TITLE
Boolean flag for consensus clustering

### DIFF
--- a/signatureanalyzer/__main__.py
+++ b/signatureanalyzer/__main__.py
@@ -162,6 +162,11 @@ def main():
         help="Random seed for decomposition",
         default=None,
     )
+    parser.add_argument(
+        '--consensus_max_samples',
+        help="Maximum number of samples to include in consensus matrix after NMF (only applies when type='matrix')",
+        default=1000,
+    )
 
     # -----------------------------------------
     # NMF Post-processing Arguments

--- a/signatureanalyzer/__main__.py
+++ b/signatureanalyzer/__main__.py
@@ -162,11 +162,6 @@ def main():
         help="Random seed for decomposition",
         default=None,
     )
-    parser.add_argument(
-        '--consensus_max_samples',
-        help="Maximum number of samples to include in consensus matrix after NMF (only applies when type='matrix')",
-        default=1000,
-    )
 
     # -----------------------------------------
     # NMF Post-processing Arguments
@@ -182,6 +177,12 @@ def main():
         help="Difference between mean selected signature and mean unselected signatures for marker selection (matrix). (default: 1.0)",
         default=1.0,
         type=float
+    )
+    parser.add_argument(
+        '--consensus_clustering',
+        help="Whether to run consensus clustering after NMF. Only applies when `--type` is 'matrix'. (default: False)\nWarning: consumes N^2 memory. Not recommended for large datasets.",
+        default=False,
+        type=bool
     )
 
     args = parser.parse_args()

--- a/signatureanalyzer/consensus.py
+++ b/signatureanalyzer/consensus.py
@@ -24,7 +24,9 @@ def consensus_cluster(filepath: str, max_samples=1000):
     """
     niter = get_nruns_from_output(filepath)
     H_selected = pd.read_hdf(filepath, "H")
-    H_selected = H_selected.sample(max_samples, replace=True)
+    
+    if H_selected.shape[0] > max_samples:
+        H_selected = H_selected.sample(max_samples, replace=True)
 
     x = np.vstack([pd.read_hdf(filepath, "run{}/H".format(i)).loc[H_selected.index,'max_id'].values for i in range(niter)])
     consensus_matrix = np.vstack([(x[:,[y]] == x[:]).sum(0) for y in range(x.shape[1])])

--- a/signatureanalyzer/consensus.py
+++ b/signatureanalyzer/consensus.py
@@ -5,17 +5,12 @@ import os
 import matplotlib.pyplot as plt
 from .utils import get_nruns_from_output
 
-def consensus_cluster(filepath: str, max_samples=1000):
+def consensus_cluster(filepath: str):
     """
     Consensus clustering of ard-nmf results.
     -----------------------
     Args:
         * filepath: path to the output .5 file of ARD-NMF runs
-
-    Kwargs:
-        * max_samples: maximum number of cells to include in the
-                       consensus matrix. If the size of H exceeds max_samples,
-                       then downsample to max_samples randomly.
 
     Returns:
         * pd.DataFrame: consensus matrix from results
@@ -25,10 +20,7 @@ def consensus_cluster(filepath: str, max_samples=1000):
     niter = get_nruns_from_output(filepath)
     H_selected = pd.read_hdf(filepath, "H")
     
-    if H_selected.shape[0] > max_samples:
-        H_selected = H_selected.sample(max_samples, replace=True)
-
-    x = np.vstack([pd.read_hdf(filepath, "run{}/H".format(i)).loc[H_selected.index,'max_id'].values for i in range(niter)])
+    x = np.vstack([pd.read_hdf(filepath, "run{}/H".format(i)).loc[:,'max_id'].values for i in range(niter)])
     consensus_matrix = np.vstack([(x[:,[y]] == x[:]).sum(0) for y in range(x.shape[1])])
 
     df = pd.DataFrame(consensus_matrix, index=H_selected.index, columns=H_selected.index)

--- a/signatureanalyzer/plotting/_nmf.py
+++ b/signatureanalyzer/plotting/_nmf.py
@@ -47,6 +47,7 @@ def consensus_matrix(
     color_thresh_scale: float = 0.3,
     figsize: tuple = (8,8),
     p: int = 30,
+    max_samples=1000,
     metas: Union[list, None] = None,
     vmax: Union[float, None] = None,
     vmin: Union[float, None] = None,
@@ -66,6 +67,8 @@ def consensus_matrix(
         * color_thresh_scale: asthetic scale for coloring of dendrogram
         * figsize: figsize
         * p: parameter for dendrogram
+        * max_samples: the maximum number of samples the consensus matrix could
+                       have included
         * meta: list of pd.Series that includes a variable of interest to plot
             to left of plot; must be categorical in nature
 
@@ -238,6 +241,9 @@ def consensus_matrix(
     for _, spine in ax.spines.items():
         spine.set_visible(True)
 
-    ax.set_xlabel("Samples", fontsize=14)
+    xlabel = "Samples"
+    if cmatrix.shape[0] == max_samples:
+        xlabel = f"Samples (downsampled to n={max_samples})"
+    ax.set_xlabel(xlabel, fontsize=14)
 
     return fig, rs

--- a/signatureanalyzer/plotting/_nmf.py
+++ b/signatureanalyzer/plotting/_nmf.py
@@ -47,7 +47,6 @@ def consensus_matrix(
     color_thresh_scale: float = 0.3,
     figsize: tuple = (8,8),
     p: int = 30,
-    max_samples=1000,
     metas: Union[list, None] = None,
     vmax: Union[float, None] = None,
     vmin: Union[float, None] = None,
@@ -67,8 +66,6 @@ def consensus_matrix(
         * color_thresh_scale: asthetic scale for coloring of dendrogram
         * figsize: figsize
         * p: parameter for dendrogram
-        * max_samples: the maximum number of samples the consensus matrix could
-                       have included
         * meta: list of pd.Series that includes a variable of interest to plot
             to left of plot; must be categorical in nature
 
@@ -241,9 +238,6 @@ def consensus_matrix(
     for _, spine in ax.spines.items():
         spine.set_visible(True)
 
-    xlabel = "Samples"
-    if cmatrix.shape[0] == max_samples:
-        xlabel = f"Samples (downsampled to n={max_samples})"
-    ax.set_xlabel(xlabel, fontsize=14)
+    ax.set_xlabel("Samples", fontsize=14)
 
     return fig, rs

--- a/signatureanalyzer/signatureanalyzer.py
+++ b/signatureanalyzer/signatureanalyzer.py
@@ -66,7 +66,7 @@ def run_maf(
             will perform decomposition using CPU.
 3    """
     try:
-        [nmf_kwargs.pop(key) for key in ['input', 'type', 'random_seed', 'consensus_max_samples']]
+        [nmf_kwargs.pop(key) for key in ['input', 'type', 'random_seed', 'consensus_clustering']]
     except:
         pass
 
@@ -195,7 +195,7 @@ def run_spectra(
             will perform decomposition using CPU.
     """
     try:
-        [nmf_kwargs.pop(key) for key in ['input', 'type', 'hg_build', 'random_seed', 'consensus_max_samples']]
+        [nmf_kwargs.pop(key) for key in ['input', 'type', 'hg_build', 'random_seed', 'consensus_clustering']]
     except:
         pass
 
@@ -284,7 +284,7 @@ def run_matrix(
     nruns: int = 20,
     verbose: bool = False,
     plot_results: bool = True,
-    consensus_max_samples: int = 1000,
+    consensus_clustering: bool = False,
     **nmf_kwargs
     ):
     """
@@ -306,8 +306,6 @@ def run_matrix(
         * outdir: output directory to save files
         * nruns: number of iterations for ARD-NMF
         * verbose: bool
-        * consensus_max_samples: maximum number of samples to include in 
-                                 consensus clustering after factorization
 
     NMF_kwargs:
         * K0: starting number of latent components
@@ -330,6 +328,10 @@ def run_matrix(
             (used in post-processing)
         * cuda_int: GPU to use. Defaults to 0. If "None" or if no GPU available,
             will perform decomposition using CPU.
+        * consensus_clustering: Whether to run consensus clustering after NMF.
+                                Default=False.
+                                WARNING: consumes N^2 memory. Not recommended
+                                for large datasets. 
     """
     try:
         [nmf_kwargs.pop(key) for key in ['input', 'type', 'hg_build', 'reference', 'random_seed']]
@@ -393,22 +395,20 @@ def run_matrix(
         store["log"] = store["run{}/log".format(best_run)]
         store["aggr"] = aggr
 
-
     # Consensus Clustering
-    print("   * Computing consensus matrix")
-    cmatrix, _ = consensus_cluster(os.path.join(outdir, 'nmf_output.h5'),
-                                   max_samples=consensus_max_samples)
-    f,d = consensus_matrix(cmatrix, n_clusters=max_k_iter, 
-                           max_samples=consensus_max_samples)
+    if consensus_clustering:
+        print("   * Computing consensus matrix")
+        cmatrix, _ = consensus_cluster(os.path.join(outdir, 'nmf_output.h5'))
+        f,d = consensus_matrix(cmatrix, n_clusters=max_k_iter) 
 
-    cmatrix.to_csv(os.path.join(outdir, 'consensus_matrix.tsv'), sep='\t')
-    d.to_csv(os.path.join(outdir, 'consensus_assign.tsv'), sep='\t')
+        cmatrix.to_csv(os.path.join(outdir, 'consensus_matrix.tsv'), sep='\t')
+        d.to_csv(os.path.join(outdir, 'consensus_assign.tsv'), sep='\t')
 
-    if plot_results: plt.savefig(os.path.join(outdir, 'consensus_matrix.pdf'), dpi=100, bbox_inches='tight')
+        if plot_results: plt.savefig(os.path.join(outdir, 'consensus_matrix.pdf'), dpi=100, bbox_inches='tight')
 
-    store = pd.HDFStore(os.path.join(outdir,'nmf_output.h5'),'a')
-    store['consensus'] = d
-    store.close()
+        store = pd.HDFStore(os.path.join(outdir,'nmf_output.h5'),'a')
+        store['consensus'] = d
+        store.close()
 
     # Plots
     if plot_results:

--- a/signatureanalyzer/signatureanalyzer.py
+++ b/signatureanalyzer/signatureanalyzer.py
@@ -284,6 +284,7 @@ def run_matrix(
     nruns: int = 20,
     verbose: bool = False,
     plot_results: bool = True,
+    consensus_max_samples: int = 1000,
     **nmf_kwargs
     ):
     """
@@ -305,6 +306,8 @@ def run_matrix(
         * outdir: output directory to save files
         * nruns: number of iterations for ARD-NMF
         * verbose: bool
+        * consensus_max_samples: maximum number of samples to include in 
+                                 consensus clustering after factorization
 
     NMF_kwargs:
         * K0: starting number of latent components
@@ -393,8 +396,10 @@ def run_matrix(
 
     # Consensus Clustering
     print("   * Computing consensus matrix")
-    cmatrix, _ = consensus_cluster(os.path.join(outdir, 'nmf_output.h5'))
-    f,d = consensus_matrix(cmatrix, n_clusters=max_k_iter)
+    cmatrix, _ = consensus_cluster(os.path.join(outdir, 'nmf_output.h5'),
+                                   max_samples=consensus_max_samples)
+    f,d = consensus_matrix(cmatrix, n_clusters=max_k_iter, 
+                           max_samples=consensus_max_samples)
 
     cmatrix.to_csv(os.path.join(outdir, 'consensus_matrix.tsv'), sep='\t')
     d.to_csv(os.path.join(outdir, 'consensus_assign.tsv'), sep='\t')

--- a/signatureanalyzer/signatureanalyzer.py
+++ b/signatureanalyzer/signatureanalyzer.py
@@ -66,7 +66,7 @@ def run_maf(
             will perform decomposition using CPU.
 3    """
     try:
-        [nmf_kwargs.pop(key) for key in ['input', 'type', 'random_seed']]
+        [nmf_kwargs.pop(key) for key in ['input', 'type', 'random_seed', 'consensus_max_samples']]
     except:
         pass
 
@@ -195,7 +195,7 @@ def run_spectra(
             will perform decomposition using CPU.
     """
     try:
-        [nmf_kwargs.pop(key) for key in ['input', 'type', 'hg_build', 'random_seed']]
+        [nmf_kwargs.pop(key) for key in ['input', 'type', 'hg_build', 'random_seed', 'consensus_max_samples']]
     except:
         pass
 


### PR DESCRIPTION
This PR adds a Boolean flag (`consensus_clustering`) for consensus clustering in (A) the command line script and (B) the run_matrix function. By default, SignatureAnalyzer will NOT run consensus clustering after NMF.

This replaces the downsampling logic of the previous commits.

The docstrings and argparse help string warn the user about consensus clustering's memory consumption.