### PR TITLE
Removed --consensus_max_samples from command line arguments

### DIFF
--- a/signatureanalyzer/__main__.py
+++ b/signatureanalyzer/__main__.py
@@ -162,11 +162,6 @@ def main():
         help="Random seed for decomposition",
         default=None,
     )
-    parser.add_argument(
-        '--consensus_max_samples',
-        help="Maximum number of samples to include in consensus matrix after NMF (only applies when type='matrix')",
-        default=1000,
-    )
 
     # -----------------------------------------
     # NMF Post-processing Arguments

--- a/signatureanalyzer/signatureanalyzer.py
+++ b/signatureanalyzer/signatureanalyzer.py
@@ -306,8 +306,6 @@ def run_matrix(
         * outdir: output directory to save files
         * nruns: number of iterations for ARD-NMF
         * verbose: bool
-        * consensus_max_samples: maximum number of samples to include in 
-                                 consensus clustering after factorization
 
     NMF_kwargs:
         * K0: starting number of latent components


### PR DESCRIPTION
Hadn't fully cleaned up the deprecated `consensus_max_samples` feature from an earlier commit, causing failures in the command line script.

This pull request fixes those problems.