### PR TITLE
aggr ARD-NMF plotting bug: pass K array to x arg

### DIFF
--- a/signatureanalyzer/plotting/_nmf.py
+++ b/signatureanalyzer/plotting/_nmf.py
@@ -30,7 +30,7 @@ def k_dist(X: np.ndarray, figsize: tuple = (8,8)):
     """
     fig,ax = plt.subplots(figsize=figsize)
 
-    sns.countplot(X, ax=ax, linewidth=2, edgecolor='k', rasterized=True)
+    sns.countplot(x=X, ax=ax, linewidth=2, edgecolor='k', rasterized=True)
     ax.set_ylim(0,ax.get_ylim()[1]+int(ax.get_ylim()[1]*0.1))
 
     ax.set_title("Aggregate of ARD-NMF (n={})".format(len(X)), fontsize=20)


### PR DESCRIPTION
The `k_dist` function is intended to generate a barplot showing the frequency of each observed **K** (number of signatures) but instead returns a uniform distribution at y=1 with as many bars as there are runs. This occurs because the Numpy array `np.array(aggr.K, dtype=int)` passed as the first positional argument to `sns.countplot` is interpreted as wide-form data, rather than long-form, due to the omitting the `x` or `y` argument. This can be resolved by passing the array to `x`.